### PR TITLE
Remove commons-lang3 from the BTA jar

### DIFF
--- a/natosatlas-bta/build.gradle.kts
+++ b/natosatlas-bta/build.gradle.kts
@@ -60,8 +60,8 @@ dependencies {
     implementation(libs.log4j.api12)
     implementation(libs.gson)
 
-    implementation(libs.commonsLang3)
-    include(libs.commonsLang3)
+    // implementation(libs.commonsLang3)
+    // include(libs.commonsLang3)
 }
 
 java {


### PR DESCRIPTION
This is not currently being utilized and adds an extra ~680kb to the final jar for no reason.