### PR TITLE
feat: use entity textures for map icons

### DIFF
--- a/natosatlas-bta/src/main/java/dev/natowb/natosatlas/bta/PlatformWorldProviderBTA.java
+++ b/natosatlas-bta/src/main/java/dev/natowb/natosatlas/bta/PlatformWorldProviderBTA.java
@@ -62,7 +62,7 @@ public class PlatformWorldProviderBTA implements PlatformWorldProvider {
 				type = NAEntity.NAEntityType.Animal;
 			}
 
-			entities.add(new NAEntity(e.x, e.y, e.z, e.yRot, type));
+			entities.add(new NAEntity(e.x, e.y, e.z, e.yRot, type).setTexturePath(e.getEntityTexture()));
 		}
 
 		return entities;

--- a/natosatlas-core/src/main/java/dev/natowb/natosatlas/core/data/NAEntity.java
+++ b/natosatlas-core/src/main/java/dev/natowb/natosatlas/core/data/NAEntity.java
@@ -1,11 +1,15 @@
 package dev.natowb.natosatlas.core.data;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class NAEntity {
     public final NAEntityType type;
     public final double x;
     public final double y;
     public final double z;
     public final double yaw;
+    public String texturePath = "/mob/char.png";
 
     public NAEntity(double x, double y, double z, double yaw, NAEntityType type) {
         this.x = x;
@@ -15,10 +19,50 @@ public class NAEntity {
         this.type = type;
     }
 
+    public NAEntity setTexturePath(String texturePath) {
+        this.texturePath = texturePath;
+        return this;
+    }
+
     public enum NAEntityType {
         Player,
         Mob,
         Animal,
         Waypoint
+    }
+
+    public static class UV {
+        public final float u1, v1, u2, v2;
+        public UV(float u1, float v1, float u2, float v2) {
+            this.u1 = u1;
+            this.v1 = v1;
+            this.u2 = u2;
+            this.v2 = v2;
+        }
+    }
+
+    public static final Map<String, UV> UV_MAP = new HashMap<>();
+
+    static {
+        UV_MAP.put("default", new UV(
+                1f / 8f,
+                1f / 4f,
+                2f / 8f,
+                2f / 4f
+        ));
+
+        UV_MAP.put("squid",   new UV(14f/64f, 15f/32f, 22f/64f, 23f/32f));
+        UV_MAP.put("spider",  new UV(39f/64f, 12f/32f, 49f/64f, 20f/32f));
+        UV_MAP.put("chicken", new UV( 2f/64f,  3f/32f,  8f/64f,  9f/32f));
+        UV_MAP.put("cow",     new UV( 6f/64f,  6f/32f, 14f/64f, 14f/32f));
+        UV_MAP.put("sheep",   new UV( 7f/64f,  7f/32f, 15f/64f, 15f/32f));
+    }
+
+    public static UV getUV(String texturePath) {
+        for (String key : UV_MAP.keySet()) {
+            if (!key.equals("default") && texturePath.contains(key))
+                return UV_MAP.get(key);
+        }
+        return UV_MAP.get("default");
     }
 }

--- a/natosatlas-core/src/main/java/dev/natowb/natosatlas/core/map/MapPainter.java
+++ b/natosatlas-core/src/main/java/dev/natowb/natosatlas/core/map/MapPainter.java
@@ -1,7 +1,6 @@
 package dev.natowb.natosatlas.core.map;
 
 import dev.natowb.natosatlas.core.NatosAtlas;
-import dev.natowb.natosatlas.core.data.NAChunk;
 import dev.natowb.natosatlas.core.data.NACoord;
 import dev.natowb.natosatlas.core.data.NAEntity;
 import dev.natowb.natosatlas.core.data.NAWorldInfo;
@@ -112,14 +111,13 @@ public class MapPainter {
         }
 
         for (NAEntity p : NatosAtlas.get().platform.worldProvider.getPlayers()) {
-            renderEntity(p, ctx.zoom);
+            renderMapMarker(p, ctx.zoom);
         }
     }
 
     public void drawWaypoints(MapContext ctx) {
-        GL11.glBindTexture(GL11.GL_TEXTURE_2D, NatosAtlas.get().platform.painter.getMinecraftTextureId("/misc/mapicons.png"));
         for (Waypoint wp : Waypoints.getAll()) {
-            renderEntity(new NAEntity(wp.x, wp.y, wp.z, 0, NAEntity.NAEntityType.Waypoint), ctx.zoom);
+            renderMapMarker(new NAEntity(wp.x, wp.y, wp.z, 0, NAEntity.NAEntityType.Waypoint), ctx.zoom);
         }
 
         for (Waypoint wp : Waypoints.getAll()) {
@@ -142,7 +140,32 @@ public class MapPainter {
 
 
     private void renderEntity(NAEntity e, double zoom) {
+        GL11.glBindTexture(
+                GL11.GL_TEXTURE_2D,
+                NatosAtlas.get().platform.painter.getMinecraftTextureId(e.texturePath)
+        );
 
+        double worldX = e.x * Constants.PIXELS_PER_CANVAS_UNIT;
+        double worldZ = e.z * Constants.PIXELS_PER_CANVAS_UNIT;
+
+        NAEntity.UV uv = NAEntity.getUV(e.texturePath);
+
+        double scale = 6 / zoom;
+
+        GL11.glPushMatrix();
+        GL11.glTranslated(worldX, worldZ, 0);
+        GL11.glRotated(180, 0, 0, 1);
+        GL11.glScaled(scale, scale, 1);
+
+        NatosAtlas.get().platform.painter.drawTexturedQuad(
+                uv.u1, uv.v1, uv.u2, uv.v2
+        );
+
+        GL11.glPopMatrix();
+    }
+
+    private void renderMapMarker(NAEntity e, double zoom) {
+        GL11.glBindTexture(GL11.GL_TEXTURE_2D, NatosAtlas.get().platform.painter.getMinecraftTextureId("/misc/mapicons.png"));
         double worldX = e.x * Constants.PIXELS_PER_CANVAS_UNIT;
         double worldZ = e.z * Constants.PIXELS_PER_CANVAS_UNIT;
 

--- a/natosatlas-modloader/src/main/java/dev/natowb/natosatlas/modloader/PlatformWorldProviderML.java
+++ b/natosatlas-modloader/src/main/java/dev/natowb/natosatlas/modloader/PlatformWorldProviderML.java
@@ -60,7 +60,7 @@ public class PlatformWorldProviderML implements PlatformWorldProvider {
                 type = NAEntity.NAEntityType.Animal;
             }
 
-            entities.add(new NAEntity(e.x, e.y, e.z, e.yaw, type));
+            entities.add(new NAEntity(e.x, e.y, e.z, e.yaw, type).setTexturePath(e.getTexture()));
         }
 
         return entities;

--- a/natosatlas-stationapi/src/main/java/dev/natowb/natosatlas/stationapi/PlatformWorldProviderST.java
+++ b/natosatlas-stationapi/src/main/java/dev/natowb/natosatlas/stationapi/PlatformWorldProviderST.java
@@ -9,6 +9,8 @@ import dev.natowb.natosatlas.core.utils.NAPaths;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.render.entity.EntityRenderDispatcher;
+import net.minecraft.client.render.entity.EntityRenderer;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.passive.AnimalEntity;
 import net.minecraft.entity.player.PlayerEntity;
@@ -60,7 +62,7 @@ public class PlatformWorldProviderST implements PlatformWorldProvider {
                 type = NAEntity.NAEntityType.Animal;
             }
 
-            entities.add(new NAEntity(e.x, e.y, e.z, e.yaw, type));
+            entities.add(new NAEntity(e.x, e.y, e.z, e.yaw, type).setTexturePath(e.getTexture()));
         }
 
         return entities;


### PR DESCRIPTION
<img width="1417" height="822" alt="image" src="https://github.com/user-attachments/assets/e1a305ec-507e-4426-ba90-b9f32ae701ed" />

we now use mob textures for the icons instead of the vanilla map player icons